### PR TITLE
修改 DELETE 方法 403问题

### DIFF
--- a/rbac-rest-service/src/main/resources/spring-mvc.xml
+++ b/rbac-rest-service/src/main/resources/spring-mvc.xml
@@ -69,6 +69,6 @@
   <!--请访问http://{ip}:{port}/rbac-rest-service/swagger-ui.html-->
 
   <mvc:cors>
-    <mvc:mapping path="/**" allowed-origins="*"/>
+    <mvc:mapping path="/**" allowed-origins="*" allowed-methods="*"/>
   </mvc:cors>
 </beans>


### PR DESCRIPTION
在 spring-mvc.xml 里配置跨域的代码中加入
allowed-methods="*"  默认配置的接受方法没有DELETE